### PR TITLE
Added backtick characters surrounding the table name in 'create database'

### DIFF
--- a/simple_db_migrate/mysql.py
+++ b/simple_db_migrate/mysql.py
@@ -107,14 +107,14 @@ class MySQL(object):
     def _drop_database(self):
         db = self.__mysql_connect(False)
         try:
-            db.query("set foreign_key_checks=0; drop database if exists %s;" % self.__mysql_db)
+            db.query("set foreign_key_checks=0; drop database if exists `%s`;" % self.__mysql_db)
         except Exception:
             raise Exception("can't drop database '%s'; database doesn't exist" % self.__mysql_db)
         db.close()
 
     def _create_database_if_not_exists(self):
         db = self.__mysql_connect(False)
-        db.query("create database if not exists %s;" % self.__mysql_db)
+        db.query("create database if not exists `%s`;" % self.__mysql_db)
         db.close()
 
     def _create_version_table_if_not_exists(self):

--- a/tests/mysql_test.py
+++ b/tests/mysql_test.py
@@ -32,7 +32,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
 
         db_mock = mox.CreateMockAnything()
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock = mox.CreateMockAnything()
@@ -90,7 +90,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
         db_mock.close()
 
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock.execute('create table if not exists __db_version__ ( id int(11) NOT NULL AUTO_INCREMENT, version varchar(20) NOT NULL default "0", label varchar(255), name varchar(255), sql_up LONGTEXT, sql_down LONGTEXT, PRIMARY KEY (id))')
@@ -341,7 +341,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
 
         db_mock = mox.CreateMockAnything()
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock = mox.CreateMockAnything()
@@ -407,7 +407,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
 
         db_mock = mox.CreateMockAnything()
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock = mox.CreateMockAnything()
@@ -474,7 +474,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
 
         db_mock = mox.CreateMockAnything()
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock = mox.CreateMockAnything()
@@ -546,7 +546,7 @@ MIGRATIONS_DIR = os.getenv("MIGRATIONS_DIR") or "."
         mysql_driver_mock = mox.CreateMockAnything()
 
         db_mock.set_character_set('utf8')
-        db_mock.query('create database if not exists migration_test;')
+        db_mock.query('create database if not exists `migration_test`;')
         db_mock.close()
 
         cursor_mock.execute('create table if not exists __db_version__ ( id int(11) NOT NULL AUTO_INCREMENT, version varchar(20) NOT NULL default "0", label varchar(255), name varchar(255), sql_up LONGTEXT, sql_down LONGTEXT, PRIMARY KEY (id))')


### PR DESCRIPTION
Added backtick characters surrounding the table name in 'create database' and 'drop database' statements in MySQL.
This allows for table names that have special characters such as hyphens, or are reserved words (since the db-name is user configurable).
See:
http://dev.mysql.com/doc/refman/5.1/en/identifiers.html

I don't believe there are any downsides or caveats to this fix. It should always work for MySQL DBs.
There didn't seem to be any easy way to add test for these types of special characters since the entire database is mocked out, so I just updated the existing tests to expect these backticks in database creation queries.
