### PR TITLE
Added a configuration property for using UTC time instead of local time w

### DIFF
--- a/example/mysql/simple-db-migrate.conf
+++ b/example/mysql/simple-db-migrate.conf
@@ -42,3 +42,12 @@ DATABASE_NAME = "migration_example"
 # DATABASE_MIGRATIONS_DIR = os.getenv("MIG_DIR") or "./migrations/dir:./another/dir"
 
 DATABASE_MIGRATIONS_DIR = os.getenv("MIG_DIR") or "."
+
+###############################################################################
+
+# Script format
+#
+# UTC_TIMESTAMP = True will cause creation scripts to utilize a UTC timestamp
+# instead of a local timestamp (default)
+#
+# UTC_TIMESTAMP = os.getenv("UTC_TIMESTAMP") or True

--- a/example/oracle/simple-db-migrate.conf
+++ b/example/oracle/simple-db-migrate.conf
@@ -48,3 +48,12 @@ DATABASE = os.getenv("DB_DATABASE") or "migrate_user"
 # DATABASE_MIGRATIONS_DIR = os.getenv("MIG_DIR") or "./migrations/dir:./another/dir"
 
 DATABASE_MIGRATIONS_DIR = os.getenv("MIG_DIR") or "."
+
+###############################################################################
+
+# Script format
+#
+# UTC_TIMESTAMP = True will cause creation scripts to utilize a UTC timestamp
+# instead of a local timestamp (default)
+#
+# UTC_TIMESTAMP = os.getenv("UTC_TIMESTAMP") or True

--- a/simple_db_migrate/config.py
+++ b/simple_db_migrate/config.py
@@ -85,6 +85,8 @@ class FileConfig(Config):
         self.put("db_engine", self.get_variable(settings, 'DATABASE_ENGINE', 'ENGINE', 'mysql'))
         self.put("db_version_table", self.get_variable(settings, 'DATABASE_VERSION_TABLE', 'VERSION_TABLE', self.DB_VERSION_TABLE))
 
+        self.put("utc_timestamp", self.get_variable(settings, 'UTC_TIMESTAMP', None, False))
+
         self.get_custom_variables(settings, ['DATABASE_HOST', 'DATABASE_USER', 'DATABASE_PASSWORD', 'DATABASE_NAME', 'DATABASE_ENGINE', 'DATABASE_VERSION_TABLE', 'DATABASE_MIGRATIONS_DIR'])
 
         migrations_dir = self.get_variable(settings, 'DATABASE_MIGRATIONS_DIR', 'MIGRATIONS_DIR')
@@ -112,7 +114,7 @@ class FileConfig(Config):
 
 class InPlaceConfig(Config):
 
-    def __init__(self, db_host, db_user, db_password, db_name, migrations_dir, db_version_table='', log_dir='', db_engine='mysql'):
+    def __init__(self, db_host, db_user, db_password, db_name, migrations_dir, db_version_table='', log_dir='', db_engine='mysql', utc_timestamp=False):
         if not db_version_table or db_version_table == '':
             db_version_table = self.DB_VERSION_TABLE
         self._config = {
@@ -123,5 +125,6 @@ class InPlaceConfig(Config):
             "db_version_table": db_version_table,
             "migrations_dir": self._parse_migrations_dir(migrations_dir),
             "log_dir": log_dir,
-            "db_engine" : db_engine
+            "db_engine" : db_engine,
+            "utc_timestamp" : utc_timestamp
         }

--- a/simple_db_migrate/core/__init__.py
+++ b/simple_db_migrate/core/__init__.py
@@ -1,4 +1,4 @@
-from time import strftime
+from time import strftime, gmtime, localtime
 import codecs
 import os
 import shutil
@@ -120,8 +120,8 @@ class Migration(object):
         return match != None
 
     @staticmethod
-    def create(migration_name, migration_dir='.', script_encoding='utf-8'):
-        timestamp = strftime("%Y%m%d%H%M%S")
+    def create(migration_name, migration_dir='.', script_encoding='utf-8', utc_timestamp = False):
+        timestamp = strftime("%Y%m%d%H%M%S", gmtime() if utc_timestamp else localtime())
         file_name = "%s_%s%s" % (timestamp, migration_name, Migration.MIGRATION_FILES_EXTENSION)
 
         if not Migration.is_file_name_valid(file_name):

--- a/simple_db_migrate/main.py
+++ b/simple_db_migrate/main.py
@@ -38,7 +38,7 @@ class Main(object):
 
     def create_migration(self):
         migrations_dir = self.config.get("migrations_dir")
-        new_file = Migration.create(self.config.get("new_migration", None), migrations_dir[0], self.config.get("db_script_encoding", "utf-8"))
+        new_file = Migration.create(self.config.get("new_migration", None), migrations_dir[0], self.config.get("db_script_encoding", "utf-8"), self.config.get("utc_timestamp", False))
         self.execution_log("- Created file '%s'" % (new_file), log_level_limit=1)
 
     def migrate(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -47,6 +47,7 @@ USERNAME = os.getenv('DB_USERNAME') or 'root'
 PASSWORD = os.getenv('DB_PASSWORD') or ''
 DATABASE = os.getenv('DB_DATABASE') or 'migration_example'
 MIGRATIONS_DIR = os.getenv('MIGRATIONS_DIR') or 'example'
+UTC_TIMESTAMP = os.getenv("UTC_TIMESTAMP") or True
 '''
         f = open('sample.conf', 'w')
         f.write(config_file)
@@ -64,6 +65,7 @@ MIGRATIONS_DIR = os.getenv('MIGRATIONS_DIR') or 'example'
         self.assertEquals(config.get('db_name'), 'migration_example')
         self.assertEquals(config.get('db_version_table'), Config.DB_VERSION_TABLE)
         self.assertEquals(config.get('migrations_dir'), [os.path.abspath('example')])
+        self.assertEquals(config.get('utc_timestamp'), True)
 
     def test_it_should_stop_execution_when_an_invalid_key_is_requested(self):
         config_path = os.path.abspath('sample.conf')
@@ -124,6 +126,7 @@ class InPlaceConfigTest(unittest.TestCase):
         self.assertEquals(config.get('db_version_table'), Config.DB_VERSION_TABLE)
         self.assertEquals(config.get('migrations_dir'), [os.path.abspath('dir')])
         self.assertEquals(config.get('log_dir'), '')
+        self.assertEquals(config.get('utc_timestamp'), False)
     
     def test_it_should_stop_execution_when_an_invalid_key_is_requested(self):
         config = InPlaceConfig('localhost', 'user', 'passwd', 'db', 'dir')

--- a/tests/core/core_test.py
+++ b/tests/core/core_test.py
@@ -20,14 +20,15 @@ def create_migration_file(file_name, sql_up='', sql_down=''):
     f.close()
     return file_name
     
-def create_config(host='localhost', username='root', password='', database='migration_example', migrations_dir='.'):
+def create_config(host='localhost', username='root', password='', database='migration_example', migrations_dir='.', utc_timestamp=False):
     config_file = '''
 HOST = os.getenv('DB_HOST') or '%s'
 USERNAME = os.getenv('DB_USERNAME') or '%s'
 PASSWORD = os.getenv('DB_PASSWORD') or '%s'
 DATABASE = os.getenv('DB_DATABASE') or '%s'
 MIGRATIONS_DIR = os.getenv('MIGRATIONS_DIR') or '%s'
-''' % (host, username, password, database, migrations_dir)
+UTC_TIMESTAMP = os.getenv("UTC_TIMESTAMP") or %s
+''' % (host, username, password, database, migrations_dir, utc_timestamp)
     f = open('test_config_file.conf', 'w')
     f.write(config_file)
     f.close()


### PR DESCRIPTION
Added a configuration property for using UTC time instead of local time when automatically generating script version numbers.
This helps developers collaborating across different timezones to create scripts which maintain proper version order based on when they were created.

I felt the configuration option was best placed in the config file, since it seems like an option you'd want to configure project wide, and not an a case-by-case basis.
The default value, if the option is not specified, is to continue using localtime(). So if users do nothing to their current config file, their functionality will remain unchanged.

The tests were my biggest questions. I did my best to add the proper tests but it seems a little sloppy. main_test in particular could probably be re-factored to more cleanly test different config file settings ( e.g. turning UTC_TIMESTAMP on or off).
