### PR TITLE
One bug, one feature

### DIFF
--- a/simple_db_migrate/main.py
+++ b/simple_db_migrate/main.py
@@ -168,18 +168,17 @@ class Main(object):
 
         is_migration_up = True
         # check if a version was passed to the program
-        if self.config.get("schema_version"):
-            # if was passed and this version is present in the database, check if is older than the current version
-            destination_version_id = self.sgdb.get_version_id_from_version_number(destination_version)
-            if destination_version_id:
-                current_version_id = self.sgdb.get_version_id_from_version_number(current_version)
-                # if this version is previous to the current version in database, then will be done a migration down to this version
-                if current_version_id > destination_version_id:
-                    is_migration_up = False
-            # if was passed and this version is not present in the database and is older than the current version, raise an exception
-            # cause is trying to go down to something that never was done
-            elif current_version > destination_version:
-                raise Exception("Trying to migrate to a lower version wich is not found on database (%s)" % destination_version)
+
+        destination_version_id = self.sgdb.get_version_id_from_version_number(destination_version)
+        if destination_version_id:
+            current_version_id = self.sgdb.get_version_id_from_version_number(current_version)
+            # if this version is previous to the current version in database, then will be done a migration down to this version
+            if current_version_id > destination_version_id:
+                is_migration_up = False
+        # if was passed and this version is not present in the database and is older than the current version, raise an exception
+        # cause is trying to go down to something that never was done
+        elif current_version > destination_version:
+            raise Exception("Trying to migrate to a lower version wich is not found on database (%s)" % destination_version)
 
         # getting only the migration sql files to be executed
         migrations_to_be_executed = self._get_migration_files_to_be_executed(current_version, destination_version, is_migration_up)


### PR DESCRIPTION
**Very small modifications, which basically brings two things with them:**
1. One fixes a bug, when trying to migrate to version 0, therefore no migration files are available on the file system.
2. One adds a small feature, when you don't pass the -m parameter, now db-migrate is able to migrate down, it it's the case (using the database or course) to the last migration file available to the file system.
