### PR TITLE
Remove values between single quotes to pass SQL validation

### DIFF
--- a/simple_db_migrate/helpers.py
+++ b/simple_db_migrate/helpers.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import re
 
 class Lists(object):
 
@@ -9,7 +10,17 @@ class Lists(object):
         return [l for l in list_a if l not in list_b]
 
 class Utils(object):
-
+    
+    @staticmethod
+    def normalize_sql(string):
+        # Basically just remove all the content between quotes so we can see if it's valid-ish later
+        
+        enclosed_quotes = re.compile("'.*?[^\\\\]'", re.S | re.U)
+        
+        sql = enclosed_quotes.sub("", string.strip())
+        
+        return sql
+    
     @staticmethod
     def count_occurrences(string):
         count = {}

--- a/simple_db_migrate/mysql.py
+++ b/simple_db_migrate/mysql.py
@@ -110,7 +110,6 @@ class MySQL(object):
             if single_quotes % 2 == 0 and double_quotes % 2 == 0 and left_parenthesis == right_parenthesis:
                 all_statements.append(curr_statement)
                 last_statement = ''
-                counter = 0
             else:
                 last_statement = curr_statement
 

--- a/simple_db_migrate/mysql.py
+++ b/simple_db_migrate/mysql.py
@@ -100,7 +100,6 @@ class MySQL(object):
                 curr_statement = statement
             
             normalized_statement = Utils.normalize_sql(curr_statement)
-            # normalized_statement = curr_statement
             
             count = Utils.count_occurrences(normalized_statement)
             single_quotes = count.get("'", 0)

--- a/tests/mysql_test.py
+++ b/tests/mysql_test.py
@@ -195,6 +195,11 @@ class MySQLTest(BaseTest):
         self.assertRaisesWithMessage(Exception, "error executing migration: invalid sql syntax 'create table foo(); create table spam());'", mysql.change,
                                      "create table foo(); create table spam());", "20090212112104", "20090212112104_test_it_should_execute_migration_down_and_update_schema_version.migration", "create table foo(); create table spam());", "drop table spam;", label_version="label")
 
+    def test_it_should_not_fail_if_column_value_contains_brackets_or_quotes(self):
+        mysql = MySQL(self.config_mock, self.db_driver_mock)
+        
+        mysql.change("create table spam( `test` varchar(255) ); insert into spam values ('(\\''''); drop table spam;", "20131212093900", "20090212112104_test_it_should_execute_migration_down_and_update_schema_version.migration", "create table spam( `test` varchar(255) );", "drop table spam;", label_version="label")
+        
     def test_it_should_stop_process_when_an_error_occur_during_database_change(self):
         self.execute_returns["insert into spam"] = Exception("invalid sql")
 


### PR DESCRIPTION
First, I'd like to apologize if this is an abomination...I don't write Python often ;)

I was running into issues with simple-db-migrate when inserting values where the TEXT column had truncated the user's input.  The statement looked like this:

INSERT INTO myTable (`id`, `text`) VALUES (1, 'Really long text that gets truncated (you know the type');

This is a perfectly valid SQL statement, but MySQL._parse_sql_statements() thought it wasn't due do the extra opening bracket.  My change removes all values between single quotes from a string so that when doing Utils.count_occurrences(), all it sees is:

INSERT INTO myTable (`id`, `text`) VALUES (1, );

The extra bracket (as well as any other crud between quotes) is removed and the query passes the smell test.

I've also added a test to catch this case - although I'm not sure if passing without an exception or assert of any kind is correct.

Thanks for taking a look.  I've only included MySQL, as I don't know the rules in other SQL flavours.
