### PR TITLE
Fix sql encoding error when raising syntax error Exception

### DIFF
--- a/simple_db_migrate/core/exceptions.py
+++ b/simple_db_migrate/core/exceptions.py
@@ -7,7 +7,7 @@ class MigrationException(Exception):
         
     def __str__(self):
         if self.sql:
-            self.details = '[ERROR DETAILS] SQL command was:\n%s' % self.sql
-            return '%s\n\n%s' % (self.msg, self.details)
+            self.details = '[ERROR DETAILS] SQL command was:\n%s' % self.sql.encode("utf-8")
+            return '%s\n\n%s' % (self.msg.encode("utf-8"), self.details)
     
         return self.msg

--- a/simple_db_migrate/mysql.py
+++ b/simple_db_migrate/mysql.py
@@ -45,7 +45,7 @@ class MySQL(object):
         try:
             statments = MySQL._parse_sql_statements(sql)
             if len(sql.strip(' \t\n\r')) != 0 and len(statments) == 0:
-                raise Exception("invalid sql syntax '%s'" % sql)
+                raise Exception("invalid sql syntax '%s'" % sql.encode("utf-8"))
 
             for statement in statments:
                 curr_statement = statement

--- a/tests/mysql_test.py
+++ b/tests/mysql_test.py
@@ -1,3 +1,4 @@
+#encoding: utf-8
 import unittest
 import sys
 import simple_db_migrate.core
@@ -194,6 +195,13 @@ class MySQLTest(BaseTest):
         mysql = MySQL(self.config_mock, self.db_driver_mock)
         self.assertRaisesWithMessage(Exception, "error executing migration: invalid sql syntax 'create table foo(); create table spam());'", mysql.change,
                                      "create table foo(); create table spam());", "20090212112104", "20090212112104_test_it_should_execute_migration_down_and_update_schema_version.migration", "create table foo(); create table spam());", "drop table spam;", label_version="label")
+
+    def test_it_should_raise_whem_migration_sql_has_a_syntax_error_sql_with_codec_error(self):
+        mysql = MySQL(self.config_mock, self.db_driver_mock)
+        expected_raised_message = u"error executing migration: invalid sql syntax 'create table foo(); create table spam()); -- ônibus'".encode("utf-8")
+        self.assertRaisesWithMessage(Exception, expected_raised_message, mysql.change,
+                                     u"create table foo(); create table spam()); -- ônibus", "20090212112104", "20090212112104_test_it_should_execute_migration_down_and_update_schema_version.migration", "create table foo(); create table spam());", "drop table spam;", label_version="label")
+
 
     def test_it_should_stop_process_when_an_error_occur_during_database_change(self):
         self.execute_returns["insert into spam"] = Exception("invalid sql")


### PR DESCRIPTION
When simple-db-migrate finds a syntax error (but the original SQL contains non-ascii chars) a second exception is raised when building the syntax error Exception. 

``` python
statments = MySQL._parse_sql_statements(sql)
    if len(sql.strip(' \t\n\r')) != 0 and len(statments) == 0:
        raise Exception("invalid sql syntax '%s'" % sql)
```

The problem is that `sql` is `unicode`, but when the string interpolation occurs the codec used is `ascii`. We must cal `sql.encode("utf-8")` before mergind its content with another `str()`.

The same occurs inside the `MigrationException` when it tries to convert itself to `str()`. I also made a similar change so I could write a test for this.
