### PR TITLE
Option --fake-execution added. Saves migration to version history wit…

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -129,6 +129,7 @@ You can set default values for internal configurations in your configuration fil
 | schema_version | the desired version of the database, will do a upgrade or a downgrade to be sure that this will be the current version of database | - | - |
 | show_sql | if True show executed SQL commands | False | True,False |
 | show_sql_only | if True only show the SQL, but do not execute them | False | True,False |
+| fake_execution | if True store migrations into version history, but do not execute them | False | True,False |
 
 h2. Supported databases engines
 

--- a/simple_db_migrate/__init__.py
+++ b/simple_db_migrate/__init__.py
@@ -48,6 +48,7 @@ def run(options):
         config.update('database_host', options.get('database_host'))
         config.update('database_port', options.get('database_port'))
         config.update('database_name', options.get('database_name'))
+        config.update('fake_execution', options.get('fake_execution'))
 
         if config.get('database_port', None):
             config.update('database_port', int(config.get('database_port')))

--- a/simple_db_migrate/cli.py
+++ b/simple_db_migrate/cli.py
@@ -171,6 +171,12 @@ class CLI(object):
                 dest="info_database",
                 default=None,
                 help="Show info of applied migrations (options: labels, last_label)"),
+
+        make_option("--fake-execution",
+                action="store_true",
+                dest="fake_execution",
+                default=False,
+                help="Modify migrations history without actually executing migrations. Use with care!"),
         )
 
     @classmethod

--- a/simple_db_migrate/mssql.py
+++ b/simple_db_migrate/mssql.py
@@ -134,8 +134,9 @@ class MSSQL(object):
         finally:
             db.close()
 
-    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None):
-        self.__execute(sql, execution_log)
+    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None, fake_execution=False):
+        if not fake_execution:
+            self.__execute(sql, execution_log)
         self.__change_db_version(new_db_version, migration_file_name, sql_up, sql_down, up, execution_log, label_version)
 
     def get_current_schema_version(self):

--- a/simple_db_migrate/mysql.py
+++ b/simple_db_migrate/mysql.py
@@ -157,8 +157,9 @@ class MySQL(object):
             sql = "insert into %s (version) values (\"0\");" % self.__version_table
             self.__execute(sql)
 
-    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None):
-        self.__execute(sql, execution_log)
+    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None, fake_execution=False):
+        if not fake_execution:
+            self.__execute(sql, execution_log)
         self.__change_db_version(new_db_version, migration_file_name, sql_up, sql_down, up, execution_log, label_version)
 
     def get_current_schema_version(self):

--- a/simple_db_migrate/oracle.py
+++ b/simple_db_migrate/oracle.py
@@ -248,8 +248,9 @@ class Oracle(object):
             sql = "insert into %s (id, version) values (%s_seq.nextval, '0')" % (self.__version_table, self.__version_table)
             self.__execute(sql)
 
-    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None):
-        self.__execute(sql, execution_log)
+    def change(self, sql, new_db_version, migration_file_name, sql_up, sql_down, up=True, execution_log=None, label_version=None, fake_execution=False):
+        if not fake_execution:
+            self.__execute(sql, execution_log)
         self.__change_db_version(new_db_version, migration_file_name, sql_up, sql_down, up, execution_log, label_version)
 
     def get_current_schema_version(self):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -132,6 +132,12 @@ class CLITest(unittest.TestCase):
     def test_it_should_accept_show_sql_only_options(self):
         self.assertEqual(True, CLI.parse(["--show-sql-only"])[0].show_sql_only)
 
+    def test_it_should_has_a_default_value_for_fake_execution(self):
+        self.assertEqual(False, CLI.parse([])[0].fake_execution)
+
+    def test_it_should_accept_fake_execution_options(self):
+        self.assertEqual(True, CLI.parse(["--fake-execution"])[0].fake_execution)
+
     def test_it_should_not_has_a_default_value_for_label_version(self):
         self.assertEqual(None, CLI.parse([])[0].label_version)
 


### PR DESCRIPTION
…hout actually running the migrations.

Hi, I have added an extra option --fake-execution. Even though it seems like a bad practice, I find it very useful in workflows, when you create and tweak your migration on development or staging server manually (and consequently getting your database to the same state, which is expected after migration). When you are finished, you can use this option to mark the migration(s) as done on particular server, so next time you run migrate, the process will not fail on your migration trying to do the same changes you've already done.

If you consider this useful for others, I'd be pleased to have my patch merged to the tree.

Best regards, and thank you very much for this project!
Jan Koriťák
