### PR TITLE
Oracle: db_version insert with CLOB

### DIFF
--- a/simple_db_migrate/oracle.py
+++ b/simple_db_migrate/oracle.py
@@ -94,6 +94,7 @@ class Oracle(object):
 
             params['migration_file_name'] = migration_file_name
             params['label'] = label_version
+            cursor.setinputsizes(sql_up = self.__driver.CLOB, sql_down = self.__driver.CLOB)
         else:
             # moving down and deleting from history
             sql = "delete from %s where version = :version" % (self.__version_table)


### PR DESCRIPTION
We got an error when executing a migration that creates a package in Oracle:

```
Starting DB migration on host/database "None/GLBCAD_STAGING" with user "cadastro2"...
- Current version is: 20170101014500
- Destination version is: 20170111104500

Starting migration up!
*** versions: ['20170111104500']

===== executing 20170111104500_pkg_glb_isp_preco_add_proc_ajustprec_prodperiodo.migration (up) =====
===== ERROR executing /mnt/GIT/coreisp/coreisp/Migrations/Cadastro/NEW_MIGRATIONS/20170111104500_pkg_glb_isp_preco_add_proc_ajustprec_prodperiodo.migration (up) =====
[ERROR] error logging migration: ORA-01461: can bind a LONG value only for insert into a LONG column


[ERROR DETAILS] SQL command was:
20170111104500_pkg_glb_isp_preco_add_proc_ajustprec_prodperiodo.migration
```

We have other migrations creating packages, some even bigger than this one. But for some reason, we got the error only with this one. 

To fix the problem I added a line to ensure the fields sql_up and sql_dow are CLOB fields.

`cursor.setinputsizes(sql_up = self.__driver.CLOB, sql_down = self.__driver.CLOB)`
