### PR TITLE
 Fix stdout encoding for python3

### DIFF
--- a/simple_db_migrate/__init__.py
+++ b/simple_db_migrate/__init__.py
@@ -10,8 +10,9 @@ from .main import Main
 SIMPLE_DB_MIGRATE_VERSION = '3.0.1'
 
 # fixing print in non-utf8 terminals
+# #42: fix for python3 encoding
 if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None and sys.stdout.encoding.upper() != 'UTF-8':
-    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+    sys.stdout = codecs.getwriter('utf-8')(sys.stdout.detach())
 
 def run_from_argv(args=None):
     (options, _) = CLI.parse(args)

--- a/simple_db_migrate/__init__.py
+++ b/simple_db_migrate/__init__.py
@@ -12,7 +12,8 @@ SIMPLE_DB_MIGRATE_VERSION = '3.0.1'
 # fixing print in non-utf8 terminals
 # #42: fix for python3 encoding
 if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None and sys.stdout.encoding.upper() != 'UTF-8':
-    sys.stdout = codecs.getwriter('utf-8')(sys.stdout.detach())
+    stdout = (sys.version_info >= (3, 1)) and sys.stdout.detach() or sys.stdout
+    sys.stdout = codecs.getwriter('utf-8')(stdout)
 
 def run_from_argv(args=None):
     (options, _) = CLI.parse(args)

--- a/tests/log_test.py
+++ b/tests/log_test.py
@@ -31,7 +31,8 @@ class LogTest(BaseTest):
     @patch('os.makedirs', side_effect=os.makedirs)
     def test_it_should_create_log_dir_if_does_not_exists(self, makedirs_mock):
         LOG('log_dir_test/path/subpath')
-        if (sys.version_info > (3, 8)):
+        if (sys.version_info >= (3, 2)):
+            # https://docs.python.org/3/library/os.html#os.makedirs
             expected_calls = [
                 call('log_dir_test/path/subpath'),
                 call('log_dir_test/path', exist_ok=False),


### PR DESCRIPTION
- [x] Fix encoding which is being discussed in #42 https://github.com/guilhermechapiewski/simple-db-migrate/commit/8133c651874a2007ea0919989eb56167caefc6d9
- [x] Fix a test for python 3.7 https://github.com/guilhermechapiewski/simple-db-migrate/commit/224f26d8d08c4cd4333d3281e4c581e529d12250

```python
>       self.assertEqual(expected_calls, makedirs_mock.mock_calls)
E       AssertionError: [call[25 chars]th'), call('log_dir_test/path', 511, False), c[27 chars]lse)] != [call[25 chars]th'),
E        call('log_dir_test/path', exist_ok=Fals[37 chars]lse)]

tests/log_test.py:52: AssertionError
```